### PR TITLE
Fixing QueryValidator test

### DIFF
--- a/tests/Core/QueryValidator.test.ts
+++ b/tests/Core/QueryValidator.test.ts
@@ -65,7 +65,7 @@ describe(`# QueryValidator tests`, () => {
 
     it(`# Should return a parser error type for querying a the wrong table name`, () => {
         type query = {
-            selected: ['columnC', 'columnB'],
+            selected: ['columnA', 'columnB'],
             tables: ['wrongName']
         }
         type model = {


### PR DESCRIPTION
Test that is supposed to check behaviour when only table name is wrong also had wrong column name